### PR TITLE
Corrected some spelling errors in sv and uniformed usage of postal code in en

### DIFF
--- a/custom_components/swemail/translations/en.json
+++ b/custom_components/swemail/translations/en.json
@@ -5,7 +5,7 @@
         "already_configured": "The entered postal code is already configured."
       },
       "error": {
-        "invalid_postcode": "The entered postcode is not valid",
+        "invalid_postcode": "The entered postal code is not valid",
         "creation_error": "An error occured while creating configuration object"
       },
       "step": {

--- a/custom_components/swemail/translations/sv.json
+++ b/custom_components/swemail/translations/sv.json
@@ -2,10 +2,10 @@
   "title": "Svensk Postutdelning",
   "config": {
       "abort": {
-        "already_configured": "Det angivna postnummret finns redan"
+        "already_configured": "Det angivna postnumret finns redan"
       },
       "error": {
-        "invalid_postcode": "Det angivna postnummret är ogilltigt",
+        "invalid_postcode": "Det angivna postnumret är ogiltigt",
         "creation_error": "Ett internt fel uppstod vid skapandet av konfigurationsobjektet"
       },
       "step": {
@@ -21,7 +21,7 @@
     },
     "options": {
       "abort": {
-        "already_configured": "Det angivna postnummret finns redan"
+        "already_configured": "Det angivna postnumret finns redan"
       },
       "step": {
         "user": {


### PR DESCRIPTION
## Summary
- Changed 'ogilltigt' to 'ogiltigt' in SV translation
- Changed 'postnummret' to 'postnumret' in SV translation
- Both 'postcode' and 'postal code' were used in EN translation, made it uniform