### PR TITLE
Removed deprecated decorator @asyncio.coroutine

### DIFF
--- a/custom_components/swemail/__init__.py
+++ b/custom_components/swemail/__init__.py
@@ -17,7 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor"]
 
-@asyncio.coroutine
 async def async_setup(hass, config):
     """Set up HASL integration"""
     


### PR DESCRIPTION
https://docs.python.org/3.10/library/asyncio-task.html#generator-based-coroutines

Support for generator-based coroutines is deprecated and is removed in Python 3.11.

Fixes #23 (i hope)

Could use some more testing