### PR TITLE
ci: unify setup-python to v6 and sync README HA badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
         
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: "actions/checkout@v6"
         
       - name: Set up Python
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
           

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![maintained](https://img.shields.io/maintenance/yes/2026.svg)
 [![hacs_badge](https://img.shields.io/badge/hacs-default-green.svg)](https://github.com/custom-components/hacs)
-[![ha_version](https://img.shields.io/badge/home%20assistant-2024.10%2B-green.svg)](https://www.home-assistant.io)
+[![ha_version](https://img.shields.io/badge/home%20assistant-2025.1%2B-green.svg)](https://www.home-assistant.io)
 ![version](https://img.shields.io/badge/version-2.1.0-green.svg)
 ![stability](https://img.shields.io/badge/stability-stable-green.svg)
 [![CI](https://github.com/DSorlov/swemail/workflows/CI/badge.svg)](https://github.com/DSorlov/swemail/actions/workflows/ci.yaml)


### PR DESCRIPTION
Follow-up to #39. Unifies remaining `actions/setup-python` to v6 (lint + HACS quality jobs) and syncs the README Home Assistant badge to 2025.1+ to match `hacs.json`.