### PR TITLE
manifest: drop aiohttp requirement

### DIFF
--- a/custom_components/swemail/manifest.json
+++ b/custom_components/swemail/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dsorlov/swemail/issues",
   "quality_scale": "silver",
-  "requirements": ["aiohttp"],
+  "requirements": [],
   "version": "2.1.0"
 }


### PR DESCRIPTION
`aiohttp` is provided by Home Assistant core, so it does not need to be listed as an integration requirement.